### PR TITLE
Minor bug fix in findTFs

### DIFF
--- a/function/findTFs_correctevent.m
+++ b/function/findTFs_correctevent.m
@@ -19,7 +19,9 @@ if ~isempty(trans_mat_files)
         iday = find(dday > 0); % find days prior to event
         [~,imin] = min(dday(iday)); % find min index
         min_idx = iday(imin); % index day nearest to event
-%         [min_diff,min_idx]=min(abs(eventid_num-tfid_num)); %find tf from closest day to event
+        if isempty(min_idx) % if no available day prior, use nearest day
+            [min_diff,min_idx]=min(abs(eventid_num-tfid_num)); %find tf from closest day to event
+        end
         dayid = tfid(min_idx,:);
         trans_filename = sprintf('%s%s_%s_transfun.mat',inpath_trans,station,dayid);
     end


### PR DESCRIPTION
Deal with rare case where there are no available spectra for day prior 
to event. In that case, just use nearest day.