### PR TITLE
Update

### DIFF
--- a/b1_dailystaspectra.m
+++ b/b1_dailystaspectra.m
@@ -48,6 +48,7 @@ for ista = 1:length(stations)
         figure(90);clf
         figure(105);clf
     end
+    day_deploy = day_filenames(1).name(1:12);
     for ie = 1 : length(day_filenames)
         if isfigure_spectrogram == 1
         figure(96);clf
@@ -197,11 +198,11 @@ for ista = 1:length(stations)
         if isfigure_powerspec
         [specprop_all] = noisecal_dailystaspectra(spectrum_Z,spectrum_H1,spectrum_H2,spectrum_P,...
             cspectrum_Z,cspectrum_H1,cspectrum_H2,cspectrum_P,ones(size(is_goodwin)),f,comp_exist,...
-            '-r',taxisZ,iptwin1,iptwin2,NFFT,dt,isfigure_powerspec,Zraw,dayid,hangs,tiltfreq,0,isfigure_orient);
+            '-r',taxisZ,iptwin1,iptwin2,NFFT,dt,isfigure_powerspec,Zraw,dayid,day_deploy,hangs,tiltfreq,0,isfigure_orient);
         end
         [specprop] = noisecal_dailystaspectra(spectrum_Z,spectrum_H1,spectrum_H2,spectrum_P,...
             cspectrum_Z,cspectrum_H1,cspectrum_H2,cspectrum_P,is_goodwin,f,comp_exist,...
-            '-k',taxisZ,iptwin1,iptwin2,NFFT,dt,isfigure_powerspec,Zraw,dayid,hangs,tiltfreq,1,isfigure_orient);
+            '-k',taxisZ,iptwin1,iptwin2,NFFT,dt,isfigure_powerspec,Zraw,dayid,day_deploy,hangs,tiltfreq,1,isfigure_orient);
         
         % Save parameters in structure
         specprop.params.f = f;
@@ -238,13 +239,20 @@ for ista = 1:length(stations)
     end
 
     if isfigure_orient && issavefigure
+
+        if isleapyear(str2double(day_deploy(1:4)))
+            year = 366;
+        else
+            year = 365;
+        end
+
         figure(105)
         subplot(121)
-        caxis([0 365])
+        clim([0 year])
         colormap jet
         colorbar
         subplot(122)
-        caxis([0 365])
+        clim([0 year])
         colormap jet
         colorbar
         set(gcf,'PaperPositionMode','manual');
@@ -258,13 +266,18 @@ for ista = 1:length(stations)
         
         figure(90)
         subplot(211)
-        caxis([0 365])
+        clim([0 365])
         colormap jet
         colorbar
+        box on
+        grid on
+        
         subplot(212)
-        caxis([0 365])
+        clim([0 365])
         colormap jet
         colorbar
+        box on
+        grid on
         set(gcf,'PaperPositionMode','manual');
         set(gcf,'PaperUnits','inches');
         set(gcf,'PaperOrientation','portrait');

--- a/b2_cleanstaspectra.m
+++ b/b2_cleanstaspectra.m
@@ -2,6 +2,10 @@
 % clean noise spectra to remove spurious days and calculate deployment
 % averages
 % Helen Janiszewski 1/2021
+% 
+% The unimportant parameters '12', '1P' and '2P' have been removed, and 'HZ' 
+% has been added, which is useful for analyzing the tilt characteristics.
+% Updated 2022-12-12, by Yuechu Wu
 
 clear; close all
 
@@ -84,26 +88,29 @@ for ista = 1:length(stations)
         % Coherence
         coh_stack(:,ie,1) = smooth(abs(specprop.cross.c1z_stack).^2./(specprop.power.c11_stack.*specprop.power.czz_stack),npts_smooth);
         coh_stack(:,ie,2) = smooth(abs(specprop.cross.c2z_stack).^2./(specprop.power.c22_stack.*specprop.power.czz_stack),npts_smooth);
-        coh_stack(:,ie,3) = smooth(abs(specprop.cross.cpz_stack).^2./(specprop.power.cpp_stack.*specprop.power.czz_stack),npts_smooth);
-        coh_stack(:,ie,4) = smooth(abs(specprop.cross.c12_stack).^2./(specprop.power.c11_stack.*specprop.power.c22_stack),npts_smooth);
-        coh_stack(:,ie,5) = smooth(abs(specprop.cross.c1p_stack).^2./(specprop.power.c11_stack.*specprop.power.cpp_stack),npts_smooth);
-        coh_stack(:,ie,6) = smooth(abs(specprop.cross.c2p_stack).^2./(specprop.power.c22_stack.*specprop.power.cpp_stack),npts_smooth);
+        coh_stack(:,ie,3) = smooth(abs(specprop.rotation.chz_stack).^2./(specprop.rotation.chh_stack.*specprop.power.czz_stack),npts_smooth);
+        coh_stack(:,ie,4) = smooth(abs(specprop.cross.cpz_stack).^2./(specprop.power.cpp_stack.*specprop.power.czz_stack),npts_smooth);
+%         coh_stack(:,ie,4) = smooth(abs(specprop.cross.c12_stack).^2./(specprop.power.c11_stack.*specprop.power.c22_stack),npts_smooth);
+%         coh_stack(:,ie,5) = smooth(abs(specprop.cross.c1p_stack).^2./(specprop.power.c11_stack.*specprop.power.cpp_stack),npts_smooth);
+%         coh_stack(:,ie,6) = smooth(abs(specprop.cross.c2p_stack).^2./(specprop.power.c22_stack.*specprop.power.cpp_stack),npts_smooth);
 
         % Phase
         ph_stack(:,ie,1) = 180/pi.*atan2(imag(specprop.cross.c1z_stack),real(specprop.cross.c1z_stack));
         ph_stack(:,ie,2) = 180/pi.*atan2(imag(specprop.cross.c2z_stack),real(specprop.cross.c2z_stack));
-        ph_stack(:,ie,3) = 180/pi.*atan2(imag(specprop.cross.cpz_stack),real(specprop.cross.cpz_stack));
-        ph_stack(:,ie,4) = 180/pi.*atan2(imag(specprop.cross.c12_stack),real(specprop.cross.c12_stack));
-        ph_stack(:,ie,5) = 180/pi.*atan2(imag(specprop.cross.c1p_stack),real(specprop.cross.c1p_stack));
-        ph_stack(:,ie,6) = 180/pi.*atan2(imag(specprop.cross.c1p_stack),real(specprop.cross.c2p_stack));
+        ph_stack(:,ie,3) = 180/pi.*atan2(imag(specprop.rotation.chz_stack),real(specprop.rotation.chz_stack));
+        ph_stack(:,ie,4) = 180/pi.*atan2(imag(specprop.cross.cpz_stack),real(specprop.cross.cpz_stack));
+%         ph_stack(:,ie,4) = 180/pi.*atan2(imag(specprop.cross.c12_stack),real(specprop.cross.c12_stack));
+%         ph_stack(:,ie,5) = 180/pi.*atan2(imag(specprop.cross.c1p_stack),real(specprop.cross.c1p_stack));
+%         ph_stack(:,ie,6) = 180/pi.*atan2(imag(specprop.cross.c1p_stack),real(specprop.cross.c2p_stack));
 
         % Admittance
         ad_stack(:,ie,1) = smooth(abs(specprop.cross.c1z_stack)./specprop.power.c11_stack,npts_smooth);
         ad_stack(:,ie,2) = smooth(abs(specprop.cross.c2z_stack)./specprop.power.c22_stack,npts_smooth);
-        ad_stack(:,ie,3) = smooth(abs(specprop.cross.cpz_stack)./specprop.power.cpp_stack,npts_smooth);
-        ad_stack(:,ie,4) = smooth(abs(specprop.cross.c12_stack)./specprop.power.c11_stack,npts_smooth);
-        ad_stack(:,ie,5) = smooth(abs(specprop.cross.c1p_stack)./specprop.power.c11_stack,npts_smooth);
-        ad_stack(:,ie,6) = smooth(abs(specprop.cross.c2p_stack)./specprop.power.c22_stack,npts_smooth);
+        ad_stack(:,ie,3) = smooth(abs(specprop.rotation.chz_stack)./specprop.rotation.chh_stack,npts_smooth);
+        ad_stack(:,ie,4) = smooth(abs(specprop.cross.cpz_stack)./specprop.power.cpp_stack,npts_smooth);
+%         ad_stack(:,ie,4) = smooth(abs(specprop.cross.c12_stack)./specprop.power.c11_stack,npts_smooth);
+%         ad_stack(:,ie,5) = smooth(abs(specprop.cross.c1p_stack)./specprop.power.c11_stack,npts_smooth);
+%         ad_stack(:,ie,6) = smooth(abs(specprop.cross.c2p_stack)./specprop.power.c22_stack,npts_smooth);
     end
 
     gooddays = QC_cleanstaspectra_days(spect,comp_exist,f,pb_dep,tolerance_dep,a_val_dep);

--- a/c2_tilt_characteristic.m
+++ b/c2_tilt_characteristic.m
@@ -4,7 +4,7 @@
 % date input by the user.
 %
 % The tilt characteristic depends on the selection of the tilt frequency
-% band, which can be obtained from Figures 2-4 plotted by b2_cleanstaspectra.m 
+% band, which can be obtained from Figures 2-4 plotted by b2_cleanstaspectra
 % and changed in the setup_paremeter. In the tilt frequency band, 
 % the coherence between Z and H is the largest, the admittance is 
 % nearly constant and the phase shift nearly zero.

--- a/c2_tilt_characteristic.m
+++ b/c2_tilt_characteristic.m
@@ -100,12 +100,12 @@ for ista = 1:length(stations) % begin station loop
             
             figure(1)
             subplot(211)
+            title(sprintf('%s-%s',network,station));
             clim([0 year]);
             colormap jet
             colorbar;
-            box on;
-            grid on;
-            title(sprintf('%s-%s',network,station));
+            box on
+            grid on
 
             subplot(212)
             clim([0 year]);
@@ -133,9 +133,9 @@ for ista = 1:length(stations) % begin station loop
         xlim([deploynum recoverynum]);
         datetick('x','mmmdd','keepticks');
         ylabel('Tilt angle (°)','FontSize',10);
-        box on;
-        grid on;
         title(sprintf('%s-%s',network,station));
+        box on
+        grid on
 
         subplot(2,1,2)
         plot(x,tiltcohs,'o','MarkerFaceColor','#2c6db3','MarkerSize',5,'MarkerEdgeColor','none');
@@ -145,8 +145,8 @@ for ista = 1:length(stations) % begin station loop
         ylabel('Coherence','FontSize',10);
         xlabel(sprintf('Date of year %s to %s',day_deploy(1:4),day_recovery(1:4)),'FontSize',10);
         set(gca,'YTick',0:0.2:1,'FontSize',10);
-        box on;
-        grid on;
+        box on
+        grid on
 
         figurename2 = sprintf('%s/%s_tilt_date.pdf',figoutpath,netsta);
         print('-dpdf',figurename2);

--- a/c2_tilt_characteristic.m
+++ b/c2_tilt_characteristic.m
@@ -1,33 +1,40 @@
 % tilt_characteristic
 %
-% Calculate and plot the tilt characteristics of seismometers during the 
+% Calculate and plot the tilt characteristics of seismometers during the
 % date input by the user.
-% The tilt characteristic depends on the selection of the tilt frequency 
-% band, which can be changed in the setup_paremeter. In the tilt frequency 
-% band, the coherence is the largest, the admittance is nearly constant 
-% and the phase shift nearly zero.
+%
+% The tilt characteristic depends on the selection of the tilt frequency
+% band, which can be obtained from Figures 2-4 plotted by b2_cleanstaspectra.m 
+% and changed in the setup_paremeter. In the tilt frequency band, 
+% the coherence between Z and H is the largest, the admittance is 
+% nearly constant and the phase shift nearly zero.
 %
 % Reference:
-% Bell S. W., D. W. Forsyth, and Y. Ruan (2015). Removing noise from the 
-% vertical component records of ocean‐bottom seismometers: results from 
-% year one of the Cascadia Initiative. Bulletin of the Seismological 
+% Bell S. W., D. W. Forsyth, and Y. Ruan (2015). Removing noise from the
+% vertical component records of ocean‐bottom seismometers: results from
+% year one of the Cascadia Initiative. Bulletin of the Seismological
 % Society of America, 105(1): 300–313. https://doi.org/10.1785/0120140054
 %
 % Yuechu Wu
 % 12131066@mail.sustech.edu.cn
 % 2022-10-08
+%
+% Added a figure with days since deployment days as the horizontal axis.
+% Start and end dates are no longer needed.
+% Updated 2022-12-12, by Yuechu Wu
 
 clear; close all;
-startDate = '2012-03-01';
-endDate   = '2012-03-30';
 
 INPUTdir = 'NOISETC_CI/DATA/NOISETC/SPECTRA';
+isfigure = [1 1]; % FIGURE SWITCH %
+% Figure 1: The horizontal axis is the number of days since deployment,
+% which requires a relatively long time to plot.
+% Figure 2: The horizontal axis is the date automatically matched,
+% the first and last days may be trimmed.
 
 
 % DO NOT EDIT BELOW
 setup_parameter;
-startnum = datenum(startDate,'yyyy-mm-dd');
-endnum   = datenum(endDate,'yyyy-mm-dd');
 figoutpath = sprintf('%s/TILT',FIGdir);
 
 if ~exist(figoutpath,'dir')
@@ -40,66 +47,110 @@ for ista = 1:length(stations) % begin station loop
     close all;
     inpath = [INPUTdir,'/',netsta];
 
-    id = 0;
-    for iday = startnum:endnum % begin date loop
-        id = id+1;
+    spectra_filenames = dir(fullfile(inpath,['*.mat']));
 
-        dayid = sprintf('%s0000',datestr(iday,'yyyymmdd'));
-        spectra_file = sprintf('%s/%s_%s_spectra.mat',inpath,netsta,dayid);
+    if isempty(spectra_filenames)
+        continue
+    end
 
-        if exist(spectra_file,'file')
-            fprintf('loading %s\n',spectra_file);
-            load(spectra_file);
+    splitname_deploy = strsplit(spectra_filenames(1).name,'_');
+    splitname_recovery = strsplit(spectra_filenames(end).name,'_');
+    day_deploy   = splitname_deploy{2};
+    day_recovery = splitname_recovery{2};
+    deploynum    = datenum(day_deploy(1:8),'yyyymmdd');
+    recoverynum  = datenum(day_recovery(1:8),'yyyymmdd');
+    x = [deploynum:recoverynum]';
 
-            f = specprop.params.f;
-            npts_smooth = floor(specprop.params.NFFT/1000)+1;
+    tiltangs = NaN(length(x),1);
+    tiltcohs = NaN(length(x),1);
 
-            % Coherence between Z and H
-            coh_stack(:,id) = smooth(abs(specprop.rotation.chz_stack).^2./(specprop.rotation.chh_stack.*specprop.power.czz_stack),npts_smooth);
+    for ie = 1:length(spectra_filenames) % begin date loop
 
-            % Admittance between Z and H
-            ad_stack(:,id) = smooth(abs(specprop.rotation.chz_stack)./specprop.rotation.chh_stack,npts_smooth);
+        splitname_ie = strsplit(spectra_filenames(ie).name,'_');
+        dayid = splitname_ie{2};
+        fprintf('loading %s\n',spectra_filenames(ie).name);
+        load(fullfile(inpath,spectra_filenames(ie).name));
 
-            tiltf = find(f>=tiltfreq(1) & f<=tiltfreq(2));
+        iday = datenum(dayid(1:8),'yyyymmdd') - deploynum + 1;
 
-            % Tilt angles are the arctangent of the admittance
-            tiltang = atand(mean(ad_stack(tiltf,id)));
-            tiltcoh = mean(coh_stack(tiltf,id));
+        f = specprop.params.f;
+        npts_smooth = floor(specprop.params.NFFT/1000)+1;
 
-        else
-            fprintf('%s does not exist!\nTilt angle and coherence are assigned to NaN\n',spectra_file);
-            tiltang = NaN;
-            tiltcoh = NaN;
-        end
+        % Coherence between Z and H
+        coh = smooth(abs(specprop.rotation.chz_stack).^2./(specprop.rotation.chh_stack.*specprop.power.czz_stack),npts_smooth);
 
-        days(id,:) = iday;
-        tiltangs(id,:) = tiltang;
-        tiltcohs(id,:) = tiltcoh;
-        
+        % Admittance between Z and H
+        admit = smooth(abs(specprop.rotation.chz_stack)./specprop.rotation.chh_stack,npts_smooth);
+
+        tiltf = find(f >= tiltfreq(1) & f <= tiltfreq(2));
+
+        % Tilt angles are the arctangent of the admittance
+        tiltang = atand(mean(admit(tiltf)));
+        tiltcoh = mean(coh(tiltf));
+
+        if isfigure(1)
+
+            plot_tilt(dayid,day_deploy,tiltang,tiltcoh);
+
+            if isleapyear(str2double(day_deploy(1:4)))
+                year = 366;
+            else
+                year = 365;
+            end
+            
+            figure(1)
+            subplot(211)
+            clim([0 year]);
+            colormap jet
+            colorbar;
+            box on;
+            grid on;
+            title(sprintf('%s-%s',network,station));
+
+            subplot(212)
+            clim([0 year]);
+            colormap jet
+            colorbar;
+            box on;
+            grid on;
+
+            figurename1 = sprintf('%s/%s_tilt_days.pdf',figoutpath,netsta);
+            print('-dpdf',figurename1);
+
+        end % end figure 1
+
+        tiltangs(iday,:) = tiltang;
+        tiltcohs(iday,:) = tiltcoh;
+
     end % end date loop
 
+    if isfigure(2)
 
-    figure(1)
+        figure(2)
 
-    subplot(2,1,1)
-    plot(days,tiltangs,'o','MarkerFaceColor','#00688B','MarkerSize',5,'MarkerEdgeColor','none');
-    xlim([startnum endnum]);
-    datetick('x','mmmdd','keepticks');
-    ylabel('Tilt angle (°)','FontSize',12);
-    grid on;
+        subplot(2,1,1)
+        plot(x,tiltangs,'o','MarkerFaceColor','#2c6db3','MarkerSize',5,'MarkerEdgeColor','none');
+        xlim([deploynum recoverynum]);
+        datetick('x','mmmdd','keepticks');
+        ylabel('Tilt angle (°)','FontSize',10);
+        box on;
+        grid on;
+        title(sprintf('%s-%s',network,station));
 
-    subplot(2,1,2)
-    plot(days,tiltcohs,'o','MarkerFaceColor','#00688B','MarkerSize',5,'MarkerEdgeColor','none');
-    xlim([startnum endnum]);
-    ylim([0 1]);
-    datetick('x','mmmdd','keepticks');
-    ylabel('Coherence','FontSize',12);
-    xlabel(sprintf('Date of year %s to %s',startDate(1:4),endDate(1:4)),'FontSize',12);
-    set(gca,'YTick',0:0.2:1,'FontSize',10);
-    grid on;
+        subplot(2,1,2)
+        plot(x,tiltcohs,'o','MarkerFaceColor','#2c6db3','MarkerSize',5,'MarkerEdgeColor','none');
+        xlim([deploynum recoverynum]);
+        ylim([0 1]);
+        datetick('x','mmmdd','keepticks');
+        ylabel('Coherence','FontSize',10);
+        xlabel(sprintf('Date of year %s to %s',day_deploy(1:4),day_recovery(1:4)),'FontSize',10);
+        set(gca,'YTick',0:0.2:1,'FontSize',10);
+        box on;
+        grid on;
 
-    % fpos=get(gcf,'Position'); fpos(3)=fpos(3)*1.3; set(gcf,'Position',fpos);
-    filename=sprintf('%s/%s_tilt.pdf',figoutpath,netsta);
-    print('-dpdf',filename)
+        figurename2 = sprintf('%s/%s_tilt_date.pdf',figoutpath,netsta);
+        print('-dpdf',figurename2);
+
+    end % end figure 2
 
 end % end station loop

--- a/function/dayofyear.m
+++ b/function/dayofyear.m
@@ -34,32 +34,4 @@ function yd = dayofyear(varargin)
         + day ...                                    % day in month
         + ( second + 60*minute + 3600*hour )/86400;  % part of day
     
-%--------------------------------------------------------------------------
-function t = isleapyear(year)
-%ISLEAPYEAR True for leap years.
-%
-%   ISLEAPYEAR(YEAR) returns 1's for the elements of YEAR that are leap
-%   years and 0's for those that are not.  If YEAR is omitted, the current
-%   year is used.  Gregorian calendar is assumed.
-%
-%   A year is a leap year if the following returns true
-%
-%       ( ~rem(year, 4) & rem(year, 100) ) | ~rem(year, 400)
-%
-%   A year is not a leap year if the following returns true
-%
-%      rem(year, 4) | ( ~rem(year, 100) & rem(year, 400) )
-
-%   Author:      Peter J. Acklam
-%   Time-stamp:  2002-03-03 12:51:45 +0100
-%   E-mail:      pjacklam@online.no
-%   URL:         http://home.online.no/~pjacklam
-
-   error(nargchk(0, 1, nargin));
-
-   if nargin == 0               % If no input argument...
-      clk = clock;              % ...get current date and time...
-      year = clk(1);            % ...and extract year.
-   end
-
-   t = ( ~rem(year, 4) & rem(year, 100) ) | ~rem(year, 400);
+return

--- a/function/isleapyear.m
+++ b/function/isleapyear.m
@@ -1,0 +1,30 @@
+function t = isleapyear(year)
+%ISLEAPYEAR True for leap years.
+%
+%   ISLEAPYEAR(YEAR) returns 1's for the elements of YEAR that are leap
+%   years and 0's for those that are not.  If YEAR is omitted, the current
+%   year is used.  Gregorian calendar is assumed.
+%
+%   A year is a leap year if the following returns true
+%
+%       ( ~rem(year, 4) & rem(year, 100) ) | ~rem(year, 400)
+%
+%   A year is not a leap year if the following returns true
+%
+%      rem(year, 4) | ( ~rem(year, 100) & rem(year, 400) )
+
+%   Author:      Peter J. Acklam
+%   Time-stamp:  2002-03-03 12:51:45 +0100
+%   E-mail:      pjacklam@online.no
+%   URL:         http://home.online.no/~pjacklam
+
+   error(nargchk(0, 1, nargin));
+
+   if nargin == 0               % If no input argument...
+      clk = clock;              % ...get current date and time...
+      year = clk(1);            % ...and extract year.
+   end
+
+   t = ( ~rem(year, 4) & rem(year, 100) ) | ~rem(year, 400);
+
+   return

--- a/function/noisecal_dailystaspectra.m
+++ b/function/noisecal_dailystaspectra.m
@@ -1,6 +1,6 @@
 function [specprop] =noisecal_dailystaspectra(spectrum_Z,spectrum_H1,spectrum_H2,spectrum_P,...
     cspectrum_Z,cspectrum_H1,cspectrum_H2,cspectrum_P,is_goodwin,f,comp_exist,linecol,...
-    taxisZ,iptwin1,iptwin2,NFFT,dt,isfigure_powerspec,Zraw,dayid,hangs,tiltfreq,calrotation,isfigure_orient);
+    taxisZ,iptwin1,iptwin2,NFFT,dt,isfigure_powerspec,Zraw,dayid,day_deploy,hangs,tiltfreq,calrotation,isfigure_orient);
 
 smoothlevel = floor(NFFT/1000)+1;
 
@@ -124,7 +124,7 @@ end
 
 if calrotation==1
     % get orientation
-    [max_coh,max_or] = spec_orient(spectrum_Z,spectrum_H1,spectrum_H2,cspectrum_Z,hangs,tiltfreq,f,isfigure_orient,dayid,is_goodwin,NFFT,dt);
+    [max_coh,max_or] = spec_orient(spectrum_Z,spectrum_H1,spectrum_H2,cspectrum_Z,hangs,tiltfreq,f,isfigure_orient,dayid,day_deploy,is_goodwin,NFFT,dt);
     % calculate needed spectral parameters for TFs down the line for
     % maximum orientation
     hang = max_or;

--- a/function/plot_cleanstaspectra.m
+++ b/function/plot_cleanstaspectra.m
@@ -1,7 +1,7 @@
 function plot_cleanstaspectra(spect,coh_stack,ph_stack,ad_stack,cc,station,f,maxpow,minpow);
 
 comporder = {'Z','H1','H2','P'};
-plotorder = {'1Z','2Z','PZ','12','1P','2P','12'};
+plotorder = {'1Z','2Z','HZ','PZ'};
 
 % Plotting Power Spectra
 figure(1)
@@ -9,8 +9,8 @@ set(gcf,'PaperPositionMode','manual');
 set(gcf,'PaperUnits','inches');
 set(gcf,'PaperOrientation','portrait');
 set(gcf,'PaperPosition',[.05 .05 8 10.5]);
-for ip=1:4
-    subplot(4,1,ip)
+for ip = 1:length(comporder)
+    subplot(length(comporder),1,ip)
     set(gca,'ColorOrder',cc,'NextPlot','replacechildren');
     loglog(f,spect(:,:,ip),'-','LineWidth',.5)%,'Color',cc')
 %     hold on
@@ -47,9 +47,9 @@ set(gcf,'PaperUnits','inches');
 set(gcf,'PaperOrientation','portrait');
 set(gcf,'PaperPosition',[.05 .05 8 10.5]);
 
-for ip=1:6
+for ip = 1:length(plotorder)
     figure(2)
-    subplot(6,1,ip)
+    subplot(length(plotorder),1,ip)
     set(gca,'ColorOrder',cc,'NextPlot','replacechildren');
     semilogx(f',coh_stack(:,:,ip),'-','LineWidth',.5);%,'Color',cc);
     hold on
@@ -61,7 +61,7 @@ for ip=1:6
     box on
     
     figure(3)
-    subplot(6,1,ip)
+    subplot(length(plotorder),1,ip)
     set(gca,'ColorOrder',cc,'NextPlot','replacechildren');
     semilogx(f',ph_stack(:,:,ip),'o','MarkerSize',1);
     hold on
@@ -73,7 +73,7 @@ for ip=1:6
     box on
     
     figure(4)
-    subplot(6,1,ip)
+    subplot(length(plotorder),1,ip)
     set(gca,'ColorOrder',cc,'NextPlot','replacechildren');
     loglog(f',ad_stack(:,:,ip),'-','LineWidth',.5)
     hold on

--- a/function/plot_tilt.m
+++ b/function/plot_tilt.m
@@ -1,0 +1,35 @@
+function plot_tilt(dayid,day_deploy,ang,coh)
+%
+% Plot angle and coherence versus days since deployment.
+% Yuechu Wu
+% 12131066@mail.sustech.edu.cn
+% 2022-12-12
+
+c = colormap('jet');
+
+if isleapyear(str2double(day_deploy(1:4)))
+    year = 366;
+else
+    year = 365;
+end
+
+days = dayofyear(str2double(dayid(1:4)),str2double(dayid(5:6)),str2double(dayid(7:8)),0,0);
+cc = interp1(1:length(c),c,((days)/(year))*(length(c)-1)+1);
+
+deploynum = datenum(day_deploy(1:8),'yyyymmdd');
+deploydate = datestr(deploynum,'yyyy-mmm-dd');
+iday = datenum(dayid(1:8),'yyyymmdd') - deploynum + 1;
+
+figure(1)
+subplot(211);hold on
+plot(iday,ang,'o','MarkerFaceColor',cc,'MarkerEdgeColor','none','MarkerSize',5);
+ylabel('Tilt angle (°)','FontSize',10);
+
+subplot(212);hold on
+plot(iday,coh,'o','MarkerFaceColor',cc,'MarkerEdgeColor','none','MarkerSize',5);
+ylim([0 1]);
+set(gca,'YTick',0:0.2:1,'FontSize',10);
+ylabel('Coherence','FontSize',10);
+xlabel(sprintf('%s (%s)','Days since deployment',deploydate),'FontSize',10);
+
+return

--- a/function/spec_orient.m
+++ b/function/spec_orient.m
@@ -1,11 +1,26 @@
-function [max_coh_fine,max_or_fine] = spec_orient(spectrum_Z,spectrum_H1,spectrum_H2,cspectrum_Z,hangs,tiltfreq,f,isfig,dayid,isgoodwin,NFFT,dt)
+function [max_coh_fine,max_or_fine] = spec_orient(spectrum_Z,spectrum_H1,spectrum_H2,cspectrum_Z,hangs,tiltfreq,f,isfig,dayid,day_deploy,isgoodwin,NFFT,dt)
+
+% plot orientation versus days since deployment.
+% fixed the bug caused by leap year.
+% Updated 2022-12-12, by Yuechu Wu
+
 
 c = colormap('jet');
 
 hangint = hangs(2)-hangs(1);
 
-days = dayofyear(str2num(dayid(1:4)),str2num(dayid(5:6)),str2num(dayid(7:8)),0,0);
-cc=interp1(1:length(c),c,((days)/(365))*(length(c)-1)+1);
+days = dayofyear(str2double(dayid(1:4)),str2double(dayid(5:6)),str2double(dayid(7:8)),0,0);
+deploynum = datenum(day_deploy(1:8),'yyyymmdd');
+deploydate = datestr(deploynum,'yyyy-mmm-dd');
+iday = datenum(dayid(1:8),'yyyymmdd') - deploynum + 1;
+
+if isleapyear(str2double(day_deploy(1:4)))
+    year = 366;
+else
+    year = 365;
+end
+
+cc=interp1(1:length(c),c,((days)/(year))*(length(c)-1)+1);
 
 for ih = 1:length(hangs)
     hang = hangs(ih);
@@ -147,11 +162,13 @@ max_or_fine = max_or_fine;
 if isfig ==1
 figure(90)
     subplot(211); hold on
-    plot(days,max_or_fine,'o','MarkerFaceColor',cc,'MarkerSize',5,'MarkerEdgeColor','none');
-    title('Orientation of Maximum Coherence'); xlabel('Days Since January 1'); ylabel('Degrees from H1'); ylim([0 360])
+    plot(iday,max_or_fine,'o','MarkerFaceColor',cc,'MarkerSize',5,'MarkerEdgeColor','none');
+    title('Orientation of maximum coherence'); ylabel('Degrees from H1'); ylim([0 360]);
+    xlabel(sprintf('%s (%s)','Days since deployment',deploydate));
     subplot(212); hold on
-    plot(days,max_coh_fine,'o','MarkerFaceColor',cc,'MarkerSize',5,'MarkerEdgeColor','none');
-    title('Value of Maximum Coherence'); xlabel('Days Since January 1'); ylabel('Coherence'); ylim([0 1])
+    plot(iday,max_coh_fine,'o','MarkerFaceColor',cc,'MarkerSize',5,'MarkerEdgeColor','none');
+    title('Value of maximum coherence'); ylabel('Coherence'); ylim([0 1]);
+    xlabel(sprintf('%s (%s)','Days since deployment',deploydate));
 end
 
 return

--- a/setup_parameter.m
+++ b/setup_parameter.m
@@ -54,7 +54,7 @@ TF_list = {'ZP','Z1','Z2-1','ZP-21','ZH','ZP-H'};
 % Correction Options
 taptime = 0.075; % taper for seismogram correction step
 
-tf_op = 2; %option for using either daily (1) or station average (2) TF in correction
+tf_op = 1; %option for using either daily (1) or station average (2) TF in correction
 
 filop = 2; %how to filter TF
 % 1 - user specified constant high pass and low pass


### PR DESCRIPTION
Hi, Helen Janiszewski, I have made a small upgrade to ATaCR. It mainly includes changed the horizontal axis of the tilt orientation and tilt angle to the number of days since deployment, fixed the bug that caused by the error of cc when a leap year exist. It is useful to change the x axis to the number of days since deployment, because some OBSs deployments exceed one year, which cannot be reflected in the original version. And removed the unimportant subfigures of the transfer function: '12', '1P' and '2P' in `b2_cleanstaspectra`, and added the parameter of 'HZ', which is useful for determine the tilt frequency band.
I hope these changes are useful to ATaCR users, and I hope you can agree to merge. Thank you very much!

Figures
<img width="893" alt="tilt_orient" src="https://user-images.githubusercontent.com/107676207/207003382-ed2093da-764a-4ab4-86ef-ea438d7ef7e5.png">
<img width="989" alt="tilt_ang" src="https://user-images.githubusercontent.com/107676207/207003418-2b936533-6576-4219-8eaa-086d9b1bc447.png">
![XFB03_coherence](https://user-images.githubusercontent.com/107676207/207003439-e4954c5a-aabb-4fca-9387-d98a6ce7a467.png)


